### PR TITLE
Add method for getting install id

### DIFF
--- a/flutter_appcenter_bundle/android/src/main/kotlin/com/github/hanabi1224/flutter_appcenter_bundle/FlutterAppcenterBundlePlugin.kt
+++ b/flutter_appcenter_bundle/android/src/main/kotlin/com/github/hanabi1224/flutter_appcenter_bundle/FlutterAppcenterBundlePlugin.kt
@@ -82,6 +82,10 @@ class FlutterAppcenterBundlePlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     result.success(Distribute.isEnabled().get())
                     return
                 }
+                "getInstallId" -> {
+                    result.success(AppCenter.getInstallId().get()?.toString())
+                    return
+                }
                 "configureDistribute" -> {
                     val value = call.arguments as Boolean
                     Distribute.setEnabled(value).get()

--- a/flutter_appcenter_bundle/ios/Classes/SwiftFlutterAppcenterBundlePlugin.swift
+++ b/flutter_appcenter_bundle/ios/Classes/SwiftFlutterAppcenterBundlePlugin.swift
@@ -46,6 +46,9 @@ public class SwiftFlutterAppcenterBundlePlugin: NSObject, FlutterPlugin {
         case "isDistributeEnabled":
             result(MSDistribute.isEnabled())
             return
+        case "getInstallId":
+            result(MSAppCenter.installId().uuidString)
+            return
         case "configureDistribute":
             MSDistribute.setEnabled(call.arguments as! Bool)
         case "configureDistributeDebug":

--- a/flutter_appcenter_bundle/lib/flutter_appcenter_bundle.dart
+++ b/flutter_appcenter_bundle/lib/flutter_appcenter_bundle.dart
@@ -59,6 +59,10 @@ class AppCenter {
     return await _methodChannel.invokeMethod('isAnalyticsEnabled');
   }
 
+  static Future<String> getInstallIdAsync() async {
+    return await _methodChannel.invokeMethod('getInstallId').then((r) => r as String);
+  }
+
   static Future configureAnalyticsAsync({@required enabled}) async {
     await _methodChannel.invokeMethod('configureAnalytics', enabled);
   }


### PR DESCRIPTION
Simple getter for accessing the InstallId property in the AppCenter SDK.

Useful when sending custom crash reports through their rest API because an install id is required.

Tested in both ios and android in an Objective-C flutter project.