### PR TITLE
Flavor for huawei

### DIFF
--- a/flutter_appcenter_bundle/android/build.gradle
+++ b/flutter_appcenter_bundle/android/build.gradle
@@ -44,6 +44,9 @@ android {
         appCenter {
             dimension "distribute"
         }
+        huawei {
+            dimension "distribute"
+        }
         googlePlay {
             isDefault true
             dimension "distribute"
@@ -59,6 +62,7 @@ dependencies {
     implementation "com.microsoft.appcenter:appcenter-crashes:$appCenterSdkVersion"
     appCenterImplementation "com.microsoft.appcenter:appcenter-distribute:${appCenterSdkVersion}"
     googlePlayImplementation "com.microsoft.appcenter:appcenter-distribute-play:${appCenterSdkVersion}"
+    huaweiImplementation "com.microsoft.appcenter:appcenter-distribute-play:${appCenterSdkVersion}"
 
     if (System.env.FLUTTER_ROOT != null) {
         println "FLUTTER_ROOT: $System.env.FLUTTER_ROOT"

--- a/flutter_appcenter_bundle/android/src/main/kotlin/com/github/hanabi1224/flutter_appcenter_bundle/FlutterAppcenterBundlePlugin.kt
+++ b/flutter_appcenter_bundle/android/src/main/kotlin/com/github/hanabi1224/flutter_appcenter_bundle/FlutterAppcenterBundlePlugin.kt
@@ -40,7 +40,7 @@ class FlutterAppcenterBundlePlugin : FlutterPlugin, MethodCallHandler, ActivityA
 
         @JvmStatic
         fun registerWith(registrar: Registrar) {
-            application = registrar.activity().application
+            application = registrar.activity()?.application
             val channel = MethodChannel(registrar.messenger(), methodChannelName)
             channel.setMethodCallHandler(FlutterAppcenterBundlePlugin())
         }

--- a/flutter_appcenter_bundle/lib/flutter_appcenter_bundle.dart
+++ b/flutter_appcenter_bundle/lib/flutter_appcenter_bundle.dart
@@ -51,10 +51,12 @@ class AppCenter {
   /// Track events
   static Future trackEventAsync(String name,
       [Map<String, String>? properties]) async {
-    await _methodChannel.invokeMethod('trackEvent', <String, dynamic>{
-      'name': name,
-      'properties': properties ?? <String, String>{},
-    });
+    if (!Platform.isWindows) {
+      await _methodChannel.invokeMethod('trackEvent', <String, dynamic>{
+        'name': name,
+        'properties': properties ?? <String, String>{},
+      });
+    }
   }
 
   /// Check whether analytics is enalbed

--- a/flutter_appcenter_bundle/pubspec.yaml
+++ b/flutter_appcenter_bundle/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hanabi1224/flutter_appcenter_bundle
 publish_to: https://pub.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
   flutter: ">=1.10.0"
 
 dependencies:


### PR DESCRIPTION
To use flavors for huawei (to exclude GMS functionalities) it needs to have another choice in flavors, essentially same as googlePlay one, but interpreted differently in app build.gradle, failing to do so build fails. 
I think that this modification  could be useful to others too.